### PR TITLE
Use existing JSON codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and requires a minimum `ex_aws` version of 2.5.1.
 ## Installation
 
 The package can be installed by adding `:ex_aws_bedrock` to your list of dependencies in `mix.exs`
-along with `:ex_aws`, `:jason` JSON codec, and your preferred HTTP client
+along with `:ex_aws`, and your preferred HTTP client and JSON codec.
 
 ```elixir
 def deps do
@@ -30,9 +30,6 @@ def deps do
   ]
 end
 ```
-
-While `ex_aws` allows you to choose JSON codec the input to the AWS models are JSON and this library
-chooses to accept maps and structs that implement the [Jason Encoder protocol](jason).
 
 ## Unit tests
 

--- a/lib/ex_aws/bedrock.ex
+++ b/lib/ex_aws/bedrock.ex
@@ -8,7 +8,7 @@ defmodule ExAws.Bedrock do
   [AWS API Docs](https://docs.aws.amazon.com/bedrock/latest/APIReference/welcome.html)
   """
 
-  @json_headers [{"Content-Type", "application/json"}]
+  @json_request_headers [{"Content-Type", "application/json"}]
 
   @doc """
   Get details about a Amazon Bedrock foundation model.
@@ -47,11 +47,9 @@ defmodule ExAws.Bedrock do
   @spec invoke_model(String.t(), Jason.Encoder.t()) :: ExAws.Operation.t()
 
   def invoke_model(model_id, inference_parameters) when is_binary(model_id) do
-    {:ok, body} = Jason.encode(inference_parameters)
-
     %ExAws.Operation.JSON{
-      data: body,
-      headers: @json_headers,
+      data: inference_parameters,
+      headers: @json_request_headers,
       http_method: :post,
       path: "/model/#{model_id}/invoke",
       service: :"bedrock-runtime"

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAws.Bedrock.MixProject do
   use Mix.Project
 
-  @version "1.5.2"
+  @version "1.5.3"
   @service "bedrock"
   @url "https://github.com/devstopfix/ex_aws_#{@service}"
   @name "ExAws.Bedrock"

--- a/test/ex_aws/bedrock_test.exs
+++ b/test/ex_aws/bedrock_test.exs
@@ -51,11 +51,6 @@ defmodule ExAws.BedrockTest do
       assert %{"results" => [%{"outputText" => _output} | _]} = request!(request)
     end
 
-    test "body as map" do
-      request = Bedrock.invoke_model(@model_id, %{})
-      assert %JSON{data: "{}"} = request
-    end
-
     test "content type is JSON", %{request: request} do
       assert %JSON{headers: headers} = request
       assert {_, "application/json"} = List.keyfind(headers, "Content-Type", 0)


### PR DESCRIPTION
JSON operation already provides JSON encoding,
though not the content type header