### PR TITLE
Update github action to use a supported version of Ubuntu as the base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,24 @@ env:
   MIX_ENV: test
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        otp: [23.x, 24.x, 25.x, 26.x]
-        elixir: [1.14.x, 1.15.x, 1.16.x]
+        otp: [24.x, 25.x, 26.x, 27.x]
+        elixir: [1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x]
         exclude:
-          - otp: 23.x
-            elixir: 1.16.x
-          - otp: 23.x
+          - otp: 24.x
+            elixir: 1.17.x
+          - otp: 24.x
+            elixir: 1.18.x
+          - otp: 26.x
+            elixir: 1.14.x
+          - otp: 27.x
+            elixir: 1.14.x
+          - otp: 27.x
             elixir: 1.15.x
+          - otp: 27.x
+            elixir: 1.16.x
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1


### PR DESCRIPTION
Right now, CI is failing because ubuntu 20.04 is no longer supported as a base image. Let's fix it!

* Update the ubuntu release used in the CI action to a supported release of Ubuntu.
* Update the elixir/OTP version matrix to include recently released elixir and OTP versions.