### PR TITLE
Honor caller http_opts (recv_timeout) on the streaming path

### DIFF
--- a/lib/ex_aws/bedrock/event_stream.ex
+++ b/lib/ex_aws/bedrock/event_stream.ex
@@ -57,8 +57,10 @@ defmodule ExAws.Bedrock.EventStream do
           encoded_data
         )
 
+      hackney_opts = hackney_options(config)
+
       request_fun = fn [] ->
-        {:ok, ref} = :hackney.post(url, full_headers, encoded_data, @hackney_options)
+        {:ok, ref} = :hackney.post(url, full_headers, encoded_data, hackney_opts)
 
         receive do
           {:hackney_response, ^ref, {:status, 200, _reason}} ->
@@ -102,6 +104,24 @@ defmodule ExAws.Bedrock.EventStream do
         )
 
       Stream.flat_map(stream, &decode_chunk/1)
+    end
+
+    @doc """
+    Builds the hackney options for the streaming request.
+
+    Merges caller-provided options from the ExAws config `:http_opts` (e.g.
+    `recv_timeout`, `connect_timeout`, `pool`) on top of the async-streaming
+    defaults. Without this, the stream would always use hackney's built-in
+    `recv_timeout` (5s) and drop slow responses regardless of the timeout the
+    caller configured.
+
+    The streaming defaults win on conflicting keys, so the async-streaming mode
+    (`async: :once`) can't be accidentally disabled by caller options.
+    """
+    def hackney_options(config) do
+      config
+      |> Map.get(:http_opts, [])
+      |> Keyword.merge(@hackney_options)
     end
 
     defp verify_event_stream!(headers) do

--- a/test/ex_aws/bedrock/event_stream_test.exs
+++ b/test/ex_aws/bedrock/event_stream_test.exs
@@ -34,6 +34,31 @@ defmodule ExAws.Bedrock.EventStreamTest do
     end
   end
 
+  describe "hackney_options/1" do
+    test "defaults to async streaming options when no http_opts are given" do
+      assert EventStream.hackney_options(%{}) == [async: :once]
+    end
+
+    test "honors caller recv_timeout / connect_timeout / pool from :http_opts" do
+      opts =
+        EventStream.hackney_options(%{
+          http_opts: [recv_timeout: 600_000, connect_timeout: 10_000, pool: :ex_aws]
+        })
+
+      assert Keyword.get(opts, :async) == :once
+      assert Keyword.get(opts, :recv_timeout) == 600_000
+      assert Keyword.get(opts, :connect_timeout) == 10_000
+      assert Keyword.get(opts, :pool) == :ex_aws
+    end
+
+    test "streaming defaults win so async: :once cannot be disabled by caller opts" do
+      opts = EventStream.hackney_options(%{http_opts: [async: false, recv_timeout: 1_000]})
+
+      assert Keyword.get(opts, :async) == :once
+      assert Keyword.get(opts, :recv_timeout) == 1_000
+    end
+  end
+
   setup_all do
     # Claude 3.5 Sonnet Multi-Chunk response
     multipart_chunk =


### PR DESCRIPTION
## Problem

`EventStream.stream_objects!/3` calls hackney with a hard-coded `@hackney_options` (`[async: :once]`) and discards the `config[:http_opts]` the caller passes. The non-streaming path forwards these through `ExAws.Request`, but the streaming path never did.

As a result, streaming always uses hackney's built-in default `recv_timeout` (5s). Because `recv_timeout` is an idle / first-byte timeout, a slow model response gets dropped with `{:closed, :timeout}` in the initial `receive` — **regardless of the timeout the caller configured** — surfacing as an empty stream even though the caller set a generous `recv_timeout`.

## Fix

Merge caller `:http_opts` (`recv_timeout`, `connect_timeout`, `pool`, …) into the hackney options via a small, testable `hackney_options/1`. The async-streaming defaults win on conflicting keys, so `async: :once` can't be accidentally disabled by caller options.

## Tests

Adds a `hackney_options/1` describe block covering:
- default async options when no `:http_opts` are given,
- caller `recv_timeout` / `connect_timeout` / `pool` being honored,
- streaming defaults winning so `async: :once` can't be overridden.

`mix test test/ex_aws/bedrock/event_stream_test.exs` → 8 tests, 0 failures.

---
For context, this was previously opened against a fork (holsee/ex_aws_bedrock#1); this PR targets the upstream library. I confirmed the issue is not already fixed on `main` (latest EventStream change was #79, hackney v4 support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)